### PR TITLE
:sparkles: Studentgroups are now ordered alphabetically

### DIFF
--- a/src/lib/api/schema.ts
+++ b/src/lib/api/schema.ts
@@ -188,7 +188,7 @@ const GET_N_MINUTES = `
 
 const GET_STUDENTGROUPS_BY_TYPE = `
     query ($type: String!) {
-        studentGroupCollection(limit: 10, where: { groupType: $type }) {
+        studentGroupCollection(order: name_ASC, limit: 10, where: { groupType: $type }) {
             items {
                 name
                 info

--- a/src/pages/om-oss.tsx
+++ b/src/pages/om-oss.tsx
@@ -82,7 +82,7 @@ const OmOssPage = ({
                 tabPanels={[
                     <>
                         <Markdown options={{ overrides: MapMarkdownChakra }}>{hvemErVi}</Markdown>
-                        <StudentGroupSection studentGroups={boards} error={boardsError} groupType="styrer" />
+                        <StudentGroupSection studentGroups={boards.reverse()} error={boardsError} groupType="styrer" />
                     </>,
                     <Markdown options={{ overrides: MapMarkdownChakra }}>{instituttraadet}</Markdown>,
                     <Markdown options={{ overrides: MapMarkdownChakra }}>{statutter}</Markdown>,


### PR DESCRIPTION
Changed the default query such that studentgroups are sorted alphabetically by default