### PR TITLE
➖ Remove dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "@emotion/styled": "11.3.0",
         "axios": "0.21.1",
         "date-fns": "2.22.1",
-        "dotenv": "10.0.0",
         "framer-motion": "4.1.17",
         "markdown-to-jsx": "7.1.3",
         "next": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,11 +3654,6 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dotenv@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
Next has built-in support for .env files, see https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables.