### PR TITLE
➖ Remove jest-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
         "eslint-plugin-react-hooks": "4.2.0",
         "husky": "7.0.0",
         "jest": "27.0.6",
-        "jest-dom": "4.0.0",
         "lint-staged": "11.0.0",
         "msw": "0.30.1",
         "prettier": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,11 +5284,6 @@ jest-docblock@^27.0.6:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-dom@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-4.0.0.tgz#94eba3cbc6576e7bd6821867c92d176de28920eb"
-  integrity sha512-gBxYZlZB1Jgvf2gP2pRfjjUWF8woGBHj/g5rAQgFPB/0K2atGuhVcPO+BItyjWeKg9zM+dokgcMOH01vrWVMFA==
-
 jest-each@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.0.6.tgz#cee117071b04060158dc8d9a66dc50ad40ef453b"


### PR DESCRIPTION
`jest-dom` is replaced by `@testing-library/jest-dom`, see https://github.com/mozilla/treeherder/commit/f844f519888c4857752bce6ed10c3dca8ac608ed.