### PR TITLE
➖ Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "@emotion/styled": "11.3.0",
         "axios": "0.21.1",
         "date-fns": "2.23.0",
-        "dotenv": "10.0.0",
         "framer-motion": "4.1.17",
         "markdown-to-jsx": "7.1.3",
         "next": "11.1.0",
@@ -63,7 +62,6 @@
         "@testing-library/user-event": "13.2.1",
         "@types/jest": "26.0.24",
         "@types/node": "14.17.9",
-        "@types/nprogress": "0.2.0",
         "@types/react": "17.0.17",
         "@types/remove-markdown": "0.3.1",
         "@typescript-eslint/eslint-plugin": "4.29.1",
@@ -76,12 +74,10 @@
         "eslint-plugin-prettier": "3.4.0",
         "husky": "7.0.1",
         "jest": "27.0.6",
-        "jest-dom": "4.0.0",
         "lint-staged": "11.1.2",
         "msw": "0.34.0",
         "prettier": "2.3.2",
         "typescript": "4.3.5",
-        "wait-on": "6.0.0",
-        "whatwg-fetch": "3.6.2"
+        "wait-on": "6.0.0"
     }
 }

--- a/src/lib/api/__tests__/bedpres.test.ts
+++ b/src/lib/api/__tests__/bedpres.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import mockResponses, { RawBedpres } from './mock-responses';

--- a/src/lib/api/__tests__/event.test.ts
+++ b/src/lib/api/__tests__/event.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import mockResponses, { RawEvent } from './mock-responses';

--- a/src/lib/api/__tests__/minute.test.ts
+++ b/src/lib/api/__tests__/minute.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import mockResponses, { RawMinute } from './mock-responses';

--- a/src/lib/api/__tests__/post.test.ts
+++ b/src/lib/api/__tests__/post.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import mockResponses, { RawPost } from './mock-responses';

--- a/src/lib/api/__tests__/student-group.test.ts
+++ b/src/lib/api/__tests__/student-group.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import mockResponses, { RawStudentGroup, RawProfile, RawRole } from './mock-responses';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,11 +2212,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.45.tgz#ec2dfb5566ff814d061aef7e141575aedba245cf"
   integrity sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==
 
-"@types/nprogress@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@types/nprogress/-/nprogress-0.2.0.tgz#86c593682d4199212a0509cc3c4d562bbbd6e45f"
-  integrity sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==
-
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -3646,11 +3641,6 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
-
-dotenv@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -5245,11 +5235,6 @@ jest-docblock@^27.0.6:
   integrity sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==
   dependencies:
     detect-newline "^3.0.0"
-
-jest-dom@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-4.0.0.tgz#94eba3cbc6576e7bd6821867c92d176de28920eb"
-  integrity sha512-gBxYZlZB1Jgvf2gP2pRfjjUWF8woGBHj/g5rAQgFPB/0K2atGuhVcPO+BItyjWeKg9zM+dokgcMOH01vrWVMFA==
 
 jest-each@^27.0.6:
   version "27.0.6"
@@ -8100,11 +8085,6 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
- Remove `dotenv`: Next has built-in support for `.env`-files, see https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables.
- Remove `jest-dom`: `jest-dom` is replaced by `@testing-library/jest-dom`, see https://github.com/mozilla/treeherder/commit/f844f519888c4857752bce6ed10c3dca8ac608ed. 
- Remove `@types/nprogress`: We no longer use `nprogress` and therefore don't need its types. 
- Remove `whatwg-fetch`: Not used.