### PR TITLE
🐛 Fix degree year text when min & max year is same

### DIFF
--- a/src/components/happening.tsx
+++ b/src/components/happening.tsx
@@ -111,7 +111,13 @@ const HappeningUI = ({
                                     (happening.minDegreeYear > 1 || happening.maxDegreeYear < 5) && (
                                         <>
                                             <Icon as={MdLockOutline} boxSize={10} />
-                                            <Text>{`Bare for ${happening.minDegreeYear}. - ${happening.maxDegreeYear}. trinn`}</Text>
+                                            <Text>
+                                                {`Bare for ${
+                                                    happening.minDegreeYear === happening.maxDegreeYear
+                                                        ? `${happening.minDegreeYear}`
+                                                        : `${happening.minDegreeYear}. - ${happening.maxDegreeYear}`
+                                                }. trinn`}
+                                            </Text>
                                         </>
                                     )}
                             </Grid>


### PR DESCRIPTION
I.e. '**Bare for 1. - 1. trinn**' now shows as '**Bare for 1. trinn**'.