### PR TITLE
🐛 Fixed countdown font and size

### DIFF
--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -7,7 +7,12 @@ const Countdown = ({ date }: { date: Date }): JSX.Element => {
 
     return (
         <Center data-testid="bedpres-not-open" my="3">
-            <Text fontWeight="bold" fontSize="5xl">
+            <Text
+                fontFamily="Open Sans"
+                fontWeight="bold"
+                fontSize={['5xl', null, null, '2xl', '3xl', '5xl']}
+                textAlign="center"
+            >
                 {hours < 10 ? `0${hours}` : hours} : {minutes < 10 ? `0${minutes}` : minutes} :{' '}
                 {seconds < 10 ? `0${seconds}` : seconds}
             </Text>


### PR DESCRIPTION
Dette burde fikse problemet alle snakker om (endelig).
Fonten er Open Sans og størrelsen forandrer seg etter skjermstørrelse.
Hadde vært fint om du/dere som reviewer sjekker det på egen device!
