### PR TITLE
🚑 Fixed rss routes

### DIFF
--- a/src/lib/generate-rss-feed.ts
+++ b/src/lib/generate-rss-feed.ts
@@ -71,7 +71,7 @@ const getRssXML = (posts: Array<Post> | null, happenings: Array<Happening> | nul
                   ),
                   author: happening.author,
                   body: happening.body,
-                  route: 'happening',
+                  route: happening.happeningType === 'BEDPRES' ? 'bedpres' : 'events',
               };
           })
         : [];


### PR DESCRIPTION
Fixed rss routes. After the refactor the links routed to `/happening` instead of `/events` or `/bedpres`.
