### PR TITLE
👽 Set useCdn to false

### DIFF
--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -5,5 +5,5 @@ export const SanityAPI = sanityClient({
     dataset: process.env.SANITY_DATASET,
     apiVersion: '2021-04-10',
     token: process.env.SANITY_TOKEN,
-    useCdn: true,
+    useCdn: false,
 });


### PR DESCRIPTION
Vi bruker ikke CDN ettersom vi bruker et privat dataset.
Så atm er det greit å sette denne til `false`, siden sanity clienten klager.
Vi får eventuelt se på i fremtiden om vi vil gå over til et public dataset, da kan vi bruke CDN.
