### PR TITLE
🔧 Make next lint work with lint-staged

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    '*.{js,jsx,ts,tsx}': (filenames) =>
+        `next lint --fix --file ${filenames.map((file) => file.split(process.cwd())[1]).join(' --file ')}`,
+    '*.{js,jsx,ts,tsx,json,md}': 'prettier --write',
+};

--- a/package.json
+++ b/package.json
@@ -15,15 +15,6 @@
         "e2e": "docker-compose down && docker-compose up --build --exit-code-from=frontend",
         "prepare": "husky install"
     },
-    "lint-staged": {
-        "*.{js,jsx,ts,tsx}": [
-            "eslint --fix",
-            "prettier --write"
-        ],
-        "*.{json,md}": [
-            "prettier --write"
-        ]
-    },
     "eslintConfig": {
         "parser": "@typescript-eslint/parser",
         "parserOptions": {


### PR DESCRIPTION
I next.js version 12 kan man linte (sjekke for feil) på individuelle filer. Dette gjør at vi kan bruke `next lint` med `lint-staged` (plugin som linter filer du prøver å commite). Endret på config for å fikse dette. Måtte flytte config fra `package.json` siden man måtte bruke litt Javascript for å gjøre om på input fra `lint-staged`.