### PR TITLE
🔧 Fix 'no-console' only producing a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
             ".next/"
         ],
         "rules": {
-            "no-console": 1,
+            "no-console": "error",
             "react/jsx-props-no-spreading": "off",
             "linebreak-style": "off",
             "camelcase": "error",


### PR DESCRIPTION
Man får bare en warning om man har med 'console.log()' i koden når man kjører eslint, endret det til en error så eslint ikke lar deg f.eks. commite med 'console.log()' i koden.