### PR TITLE
🐛 Fix broken workflow

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0
 
       - name: Automatic rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
Man kan ikke bruke GITHUB_TOKEN, siden da kjører ikke workflows som blir trigget av den workflowen som brukte GITHUB_TOKEN (for å forhindre uendelige loops med workflows elns). Derfor så kjører ikke tester på pull requester som blir trigget av rebase-workflowen (siden den bruker GITHUB_TOKEN). La til en Personal Access Token fra min GitHub, burde funke. Kanskje lage en egen Bot-bruker senere så man ikke må bruke personlig GitHub-bruker.