### PR TITLE
🚑 Fixed page refresh

### DIFF
--- a/src/pages/bedpres/[slug].tsx
+++ b/src/pages/bedpres/[slug].tsx
@@ -29,7 +29,7 @@ const BedpresPage = ({ happening, backendUrl, spotRangeCounts, date, error }: Pr
 
     /* eslint-disable @typescript-eslint/no-floating-promises */
     useTimeout(() => {
-        router.replace(router.asPath, undefined, { scroll: false });
+        if (happening?.registrationDate) router.replace(router.asPath, undefined, { scroll: false });
     }, time);
     /* eslint-enable @typescript-eslint/no-floating-promises */
 


### PR DESCRIPTION
`bedpres/[slug]` refresher constant dersom ikke registration date er definert.
Kjapp hotfix, burde kanskje gjøre registration date required, dersom happening er av type bedpres.

Logikken for dette her er helt ute å kjører, men her er en kjapp hotfix.
