### PR TITLE
Symmetrical front page sections

### DIFF
--- a/src/components/button-link.tsx
+++ b/src/components/button-link.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps, Center, LinkBox, LinkOverlay, useColorModeValue } from '@chakra-ui/react';
+import { Button, ButtonProps, LinkBox, LinkOverlay, useColorModeValue } from '@chakra-ui/react';
 import NextLink from 'next/link';
 
 interface Props extends ButtonProps {
@@ -13,24 +13,22 @@ const ButtonLink = ({ linkTo, isExternal = false, ...props }: Props): JSX.Elemen
     const textColor = useColorModeValue('button.light.text', 'button.dark.text');
 
     return (
-        <Center>
-            <LinkBox>
-                <NextLink href={linkTo} passHref>
-                    <LinkOverlay isExternal={isExternal}>
-                        <Button
-                            bg={bg}
-                            color={textColor}
-                            _hover={{ bg: hover }}
-                            _active={{ borderColor: active }}
-                            fontSize="xl"
-                            borderRadius="0.5rem"
-                            data-cy={linkTo}
-                            {...props}
-                        />
-                    </LinkOverlay>
-                </NextLink>
-            </LinkBox>
-        </Center>
+        <LinkBox>
+            <NextLink href={linkTo} passHref>
+                <LinkOverlay isExternal={isExternal}>
+                    <Button
+                        bg={bg}
+                        color={textColor}
+                        _hover={{ bg: hover }}
+                        _active={{ borderColor: active }}
+                        fontSize="xl"
+                        borderRadius="0.5rem"
+                        data-cy={linkTo}
+                        {...props}
+                    />
+                </LinkOverlay>
+            </NextLink>
+        </LinkBox>
     );
 };
 

--- a/src/components/entry-box.tsx
+++ b/src/components/entry-box.tsx
@@ -1,4 +1,4 @@
-import { Center, Heading, Text, useBreakpointValue } from '@chakra-ui/react';
+import { BoxProps, Flex, Heading, Spacer, Text, useBreakpointValue } from '@chakra-ui/react';
 import React from 'react';
 import { Happening, Post } from '../lib/api';
 import ButtonLink from './button-link';
@@ -6,7 +6,7 @@ import EntryList from './entry-list';
 import ErrorBox from './error-box';
 import Section from './section';
 
-interface Props {
+interface Props extends BoxProps {
     title?: string;
     titles?: Array<string>;
     entries: Array<Happening | Post> | null;
@@ -28,31 +28,27 @@ const EntryBox = ({
     linkTo,
     type,
     direction = 'column',
+    ...props
 }: Props): JSX.Element => {
     const choices = titles ?? [title];
     const heading = useBreakpointValue(choices); // cannot call hooks conditionally
 
     return (
-        <Section data-cy={`entry-box-${type}`}>
-            {heading && (
-                <Center minW="0">
-                    <Heading mb="5">{heading}</Heading>
-                </Center>
-            )}
-            {!entries && error && <ErrorBox error={error} />}
-            {altText && entries && !error && entries.length === 0 && (
-                <Center>
-                    <Text>{altText}</Text>
-                </Center>
-            )}
-            {entries && !error && entries.length > 0 && (
-                <EntryList entries={entries} entryLimit={entryLimit} type={type} direction={direction} />
-            )}
-            {linkTo && (
-                <ButtonLink linkTo={linkTo} mt="1.5rem">
-                    Se mer
-                </ButtonLink>
-            )}
+        <Section w="100%" h="100%" data-cy={`entry-box-${type}`} {...props}>
+            <Flex h="100%" direction="column" alignItems="center">
+                {heading && <Heading mb="5">{heading}</Heading>}
+                {!entries && error && <ErrorBox error={error} />}
+                {altText && entries && !error && entries.length === 0 && <Text>{altText}</Text>}
+                {entries && !error && entries.length > 0 && (
+                    <EntryList entries={entries} entryLimit={entryLimit} type={type} direction={direction} />
+                )}
+                <Spacer />
+                {linkTo && (
+                    <ButtonLink linkTo={linkTo} mt="1.5rem">
+                        Se mer
+                    </ButtonLink>
+                )}
+            </Flex>
         </Section>
     );
 };

--- a/src/components/entry-list.tsx
+++ b/src/components/entry-list.tsx
@@ -17,7 +17,7 @@ const EntryList = ({ entries, entryLimit, type, direction = 'column' }: Props): 
         entries = entries.length > entryLimit ? entries.slice(0, entryLimit) : entries;
     }
     return (
-        <Stack spacing={5} divider={<StackDivider />} direction={direction} justifyContent="space-around">
+        <Stack w="100%" spacing={5} divider={<StackDivider />} direction={direction} justifyContent="space-around">
             {entries.map((entry: Happening | Post) => {
                 switch (type) {
                     case 'bedpres':

--- a/src/components/hsp.tsx
+++ b/src/components/hsp.tsx
@@ -1,4 +1,13 @@
-import { Center, Heading, LinkBox, LinkOverlay, useBreakpointValue, useColorModeValue } from '@chakra-ui/react';
+import {
+    Box,
+    Center,
+    Flex,
+    Heading,
+    LinkBox,
+    LinkOverlay,
+    useBreakpointValue,
+    useColorModeValue,
+} from '@chakra-ui/react';
 import Image from 'next/image';
 import NextLink from 'next/link';
 import React from 'react';
@@ -17,21 +26,23 @@ const Hsp = (): JSX.Element => {
     ]);
 
     return (
-        <Section>
-            <Center minW="0" wordBreak="break-word">
+        <Section h="100%">
+            <Flex h="100%" direction="column" justifyContent="center" alignItems="center ">
                 <Heading mb=".5em" sizes={['xs', 'md']}>
                     {heading}
                 </Heading>
-            </Center>
-            <Center>
-                <LinkBox pb="16px">
-                    <NextLink href="https://bekk.no" passHref>
-                        <LinkOverlay isExternal filter={logoFilter}>
-                            <Image alt="Bekk" src={bekkLogo} width={300} height={72} />
-                        </LinkOverlay>
-                    </NextLink>
-                </LinkBox>
-            </Center>
+                <Box flex="1">
+                    <Center h="100%">
+                        <LinkBox>
+                            <NextLink href="https://bekk.no" passHref>
+                                <LinkOverlay isExternal filter={logoFilter}>
+                                    <Image alt="Bekk" src={bekkLogo} width={300} height={72} />
+                                </LinkOverlay>
+                            </NextLink>
+                        </LinkBox>
+                    </Center>
+                </Box>
+            </Flex>
         </Section>
     );
 };

--- a/src/components/post-preview.tsx
+++ b/src/components/post-preview.tsx
@@ -15,7 +15,7 @@ const PostPreview = ({ post }: Props): JSX.Element => {
     const textColor = useColorModeValue('text.light.secondary', 'text.dark.secondary');
 
     return (
-        <LinkBox w={['100%', null, null, null, '24em']} data-testid={post.slug}>
+        <LinkBox w={['100%', null, null, null, '22em']} data-testid={post.slug}>
             <NextLink href={`/posts/${post.slug}`} passHref>
                 <LinkOverlay>
                     <Box

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { GridItem, SimpleGrid, Stack, useBreakpointValue } from '@chakra-ui/react';
+import { Grid, GridItem, useBreakpointValue, VStack } from '@chakra-ui/react';
 import { isBefore, isFuture } from 'date-fns';
 import { GetStaticProps } from 'next';
 import React from 'react';
@@ -27,10 +27,29 @@ const IndexPage = ({
     return (
         <>
             <SEO title="echo – Fagutvalget for informatikk" />
-            <SimpleGrid columns={[1, null, null, 2]} spacing="5" mb="5">
-                <GridItem rowStart={[2, null, null, 1]}>
-                    <Stack minW="0" spacing="5">
+            <VStack spacing="5" mb="5">
+                <Grid w="100%" gap={5} templateColumns={['1', null, null, 'repeat(2, 1fr)']}>
+                    <GridItem>
                         <Hsp />
+                    </GridItem>
+                    <GridItem rowSpan={2}>
+                        <EntryBox
+                            titles={[
+                                'Bedpres',
+                                'Bedpresolini',
+                                'Bedriftspresentasjoner',
+                                'Bedpres',
+                                'Bedriftspresentasjoner',
+                            ]}
+                            entries={bedpreses}
+                            entryLimit={3}
+                            error={bedpresError}
+                            altText="Ingen kommende bedriftspresentasjoner :("
+                            linkTo="/bedpres"
+                            type="bedpres"
+                        />
+                    </GridItem>
+                    <GridItem>
                         <EntryBox
                             title="Arrangementer"
                             entries={events}
@@ -40,38 +59,19 @@ const IndexPage = ({
                             linkTo="/event"
                             type="event"
                         />
-                    </Stack>
-                </GridItem>
-                <GridItem>
-                    <EntryBox
-                        titles={[
-                            'Bedpres',
-                            'Bedpresolini',
-                            'Bedriftspresentasjoner',
-                            'Bedpres',
-                            'Bedriftspresentasjoner',
-                        ]}
-                        entries={bedpreses}
-                        entryLimit={3}
-                        error={bedpresError}
-                        altText="Ingen kommende bedriftspresentasjoner :("
-                        linkTo="/bedpres"
-                        type="bedpres"
-                    />
-                </GridItem>
-                <GridItem colSpan={[1, null, null, 2]}>
-                    <EntryBox
-                        titles={['Innlegg']}
-                        entries={posts}
-                        entryLimit={useBreakpointValue([2, 2, 2, 2, 2, 3, 4])}
-                        error={postsError}
-                        altText="Ingen innlegg :("
-                        linkTo="/posts"
-                        type="post"
-                        direction={useBreakpointValue(['column', 'column', 'column', 'row'])}
-                    />
-                </GridItem>
-            </SimpleGrid>
+                    </GridItem>
+                </Grid>
+                <EntryBox
+                    titles={['Innlegg']}
+                    entries={posts}
+                    entryLimit={useBreakpointValue([2, 2, 2, 2, 2, 3, 4])}
+                    error={postsError}
+                    altText="Ingen innlegg :("
+                    linkTo="/posts"
+                    type="post"
+                    direction={useBreakpointValue(['column', 'column', 'column', 'row'])}
+                />
+            </VStack>
         </>
     );
 };


### PR DESCRIPTION
Forsiden skal nå være mer symmetrisk.
Mange små endringer i koden for å fikse opp i dette. En del av chakra-koden er "optimalisert".  Har fjerna sykt mange `<Center />`-tags, siden de er en ganske hacky måte å sentrere ting på.

Ellers ta en titt på koden.

Should look something like this:
![image](https://user-images.githubusercontent.com/11030698/151222297-a467854b-364e-4cda-a1f3-495ca7fb280e.png)

**Note**
hsp-section blir ganske stor med mye tomrom når det er få eller ingen arrangementer siden disse da tar opp like mye plass. Vet ikke om vi vil gjøre noe med dette, eller bare la det stå. Det ser slik ut:
![image](https://user-images.githubusercontent.com/11030698/151222921-57d7184a-de4d-44a4-99ed-8e6b57605663.png)