### PR TITLE
🐛 Fix sub routes not working on non-static pages

### DIFF
--- a/src/components/info-panels.tsx
+++ b/src/components/info-panels.tsx
@@ -13,25 +13,29 @@ const InfoPanels = ({ tabNames, tabPanels }: Props): JSX.Element => {
     // force eslint to not remove optional chaining operator.
     const router = useRouter() as NextRouter | null;
 
-    // Same here, eslint is dumb.
-    const rawT: Array<string> | string | undefined = router?.query.t;
-    const t = rawT?.toString() ?? tabNames[0];
+    const queryKey = 't';
+    const queryValue = decodeURIComponent(
+        (router?.query[queryKey] ?? router?.asPath.match(new RegExp(`[&?]${queryKey}=(.*)(&|$)`)))?.toString() ??
+            tabNames[0],
+    );
 
-    const initialIndex = tabNames.includes(t) ? tabNames.indexOf(t) : 0;
+    const initialIndex = tabNames.includes(queryValue) ? tabNames.indexOf(queryValue) : 0;
     const [tabIndex, setTabIndex] = useState(initialIndex);
 
-    /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
-        const query = tabIndex === 0 ? undefined : { t: tabNames[tabIndex] };
+        if (tabNames.includes(queryValue)) {
+            setTabIndex(tabNames.indexOf(queryValue));
+        }
+    }, [queryValue, tabNames, tabIndex, setTabIndex]);
 
-        void router?.replace({ pathname: router.pathname, query: query }, undefined, {
-            shallow: false,
-        });
-    }, [tabIndex]);
-    /* eslint-enable react-hooks/exhaustive-deps */
+    const changeTab = (index: number) => {
+        setTabIndex(index);
+        const query = index === 0 ? undefined : encodeURIComponent(tabNames[index]);
+        void router?.replace({ pathname: router.pathname, query: { t: query } });
+    };
 
     return (
-        <Tabs isLazy onChange={setTabIndex} defaultIndex={tabIndex} orientation="vertical" data-testid="info-panels">
+        <Tabs isLazy onChange={changeTab} index={tabIndex} orientation="vertical" data-testid="info-panels">
             <Grid w="100%" templateColumns={['repeat(1, 1fr)', null, null, 'repeat(4, 1fr)']} gap="4">
                 <GridItem minW="0" maxW="100%" colSpan={1}>
                     <Section>

--- a/src/pages/for-studenter/index.tsx
+++ b/src/pages/for-studenter/index.tsx
@@ -1,5 +1,5 @@
 import Markdown from 'markdown-to-jsx';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps } from 'next';
 import React from 'react';
 import anononymeTilbakemeldinger from '../../../public/static/for-studenter/anonymeTilbakemeldinger.md';
 import masterinfo from '../../../public/static/for-studenter/masterinfo.md';
@@ -78,7 +78,7 @@ const ForStudenterPage = ({
     );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
     const subGroups = await StudentGroupAPI.getStudentGroupsByType('subgroup');
     const subOrgs = await StudentGroupAPI.getStudentGroupsByType('suborg');
     const intGroups = await StudentGroupAPI.getStudentGroupsByType('intgroup');


### PR DESCRIPTION
Funka ikke på `/for-bedrifter` og `/om-oss`. Nå er også `/for-studenter` static igjen.

Er et helvete med router, kopierte han duden her https://github.com/vercel/next.js/discussions/11484#discussioncomment-60563.