### PR TITLE
Fixed posts direction bug

### DIFF
--- a/src/components/entry-box.tsx
+++ b/src/components/entry-box.tsx
@@ -15,7 +15,6 @@ interface Props extends BoxProps {
     altText?: string;
     linkTo?: string;
     type: 'event' | 'bedpres' | 'post';
-    direction?: 'column' | 'row';
 }
 
 const EntryBox = ({
@@ -27,7 +26,6 @@ const EntryBox = ({
     altText,
     linkTo,
     type,
-    direction = 'row',
     ...props
 }: Props): JSX.Element => {
     const choices = titles ?? [title];
@@ -40,7 +38,7 @@ const EntryBox = ({
                 {!entries && error && <ErrorBox error={error} />}
                 {altText && entries && !error && entries.length === 0 && <Text>{altText}</Text>}
                 {entries && !error && entries.length > 0 && (
-                    <EntryList entries={entries} entryLimit={entryLimit} type={type} direction={direction} />
+                    <EntryList entries={entries} entryLimit={entryLimit} type={type} />
                 )}
                 <Spacer />
                 {linkTo && (

--- a/src/components/entry-list.tsx
+++ b/src/components/entry-list.tsx
@@ -9,15 +9,21 @@ interface Props {
     entries: Array<Happening | Post>;
     entryLimit?: number;
     type: 'event' | 'bedpres' | 'post';
-    direction: 'column' | 'row';
 }
 
-const EntryList = ({ entries, entryLimit, type, direction = 'column' }: Props): JSX.Element => {
+const EntryList = ({ entries, entryLimit, type }: Props): JSX.Element => {
     if (entryLimit) {
         entries = entries.length > entryLimit ? entries.slice(0, entryLimit) : entries;
     }
+
     return (
-        <Stack w="100%" spacing={5} divider={<StackDivider />} direction={direction} justifyContent="space-around">
+        <Stack
+            w="100%"
+            spacing={5}
+            divider={<StackDivider />}
+            direction={type === 'post' ? ['column', null, null, 'row'] : 'column'}
+            justifyContent="space-around"
+        >
             {entries.map((entry: Happening | Post) => {
                 switch (type) {
                     case 'bedpres':

--- a/src/components/entry-overview.tsx
+++ b/src/components/entry-overview.tsx
@@ -31,7 +31,6 @@ const EntryOverview = ({ entries, error, type }: Props): JSX.Element => {
                     error={error}
                     altText={`Ingen tidligere ${alt}.`}
                     type={type}
-                    direction="column"
                 />
             </GridItem>
             <GridItem rowStart={1}>
@@ -41,7 +40,6 @@ const EntryOverview = ({ entries, error, type }: Props): JSX.Element => {
                     error={error}
                     altText={`Ingen kommende ${alt}.`}
                     type={type}
-                    direction="column"
                 />
             </GridItem>
         </SimpleGrid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,6 @@ const IndexPage = ({
                             altText="Ingen kommende bedriftspresentasjoner :("
                             linkTo="/bedpres"
                             type="bedpres"
-                            direction="column"
                         />
                     </GridItem>
                     <GridItem>
@@ -59,7 +58,6 @@ const IndexPage = ({
                             altText="Ingen kommende arrangementer :("
                             linkTo="/event"
                             type="event"
-                            direction="column"
                         />
                     </GridItem>
                 </Grid>
@@ -71,7 +69,6 @@ const IndexPage = ({
                     altText="Ingen innlegg :("
                     linkTo="/posts"
                     type="post"
-                    direction={useBreakpointValue(['column', 'column', 'row', 'row'])}
                 />
             </VStack>
         </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,7 +64,7 @@ const IndexPage = ({
                 <EntryBox
                     titles={['Innlegg']}
                     entries={posts}
-                    entryLimit={useBreakpointValue([2, 2, 2, 2, 2, 3, 4])}
+                    entryLimit={useBreakpointValue([3, 3, 3, 2, 2, 3, 4])}
                     error={postsError}
                     altText="Ingen innlegg :("
                     linkTo="/posts"


### PR DESCRIPTION
Fikset denne buggen: [https://trello.com/c/9VhqAxc4/90-fikse-direction-bug-for-posts-p%C3%A5-forsiden](https://trello.com/c/9VhqAxc4/90-fikse-direction-bug-for-posts-p%C3%A5-forsiden)
Vi har tidligere bare passet `direction` ned til `entry-list`, selvom den kun er annerledes for posts. Skrev derfor om til at direction er bestemt av `type` i `entry-list`.

Merk: Dersom vi vil bruke `entry-box` med posts på et senere tidspunkt så bør vi nok tenke på refaktorisere hele opplegget her.