### PR TITLE
:iphone: Improved responsiveness

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,7 +11,7 @@ const Header = (): JSX.Element => {
 
     return (
         <Center borderColor={borderBg} data-testid="header-standard" m="2rem auto">
-            <Flex w="100%" h="120px" alignItems="flex-end" maxW="1700" px={['5%', '10%']}>
+            <Flex w="100%" h="120px" alignItems="flex-end" maxW="1600px" px={['5%', '100px']}>
                 <HeaderLogo />
                 <NavBar isOpen={isOpen} onClose={onClose} btnRef={menuButtonRef} />
                 <IconButton

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -13,7 +13,13 @@ const Layout = ({ children }: Props): JSX.Element => {
         <Box overflow="hidden" pos="relative" minHeight="100vh" data-testid="layout">
             <AnimatedIcons n={50}>
                 <Header />
-                <Box maxW="2000" m="auto" px={['5%', '10%']} pb={['380px', '300px', '200px', '160px', '160px']}>
+                <Box
+                    maxW="2000"
+                    w="100%"
+                    m="auto"
+                    px={['5%', '100px']}
+                    pb={['380px', '300px', '200px', '160px', '160px']}
+                >
                     {children}
                 </Box>
                 <Footer />


### PR DESCRIPTION
Gjorde det sånn at paddingen på siden av header og layout ikke prosentvis øker med bredden. Dette førte til at alt med mindre igjen på stor skjerm.

# Før
![før](https://user-images.githubusercontent.com/32321558/154762919-b1b02935-4e43-4f9b-8205-23fe0f385301.png)

# Etter
![etter](https://user-images.githubusercontent.com/32321558/154763139-55196ae3-05e5-44b0-b4fb-077553e6d9ed.png)
