### PR TITLE
Bedre "responsiveness" på større skjermer

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,7 +11,7 @@ const Header = (): JSX.Element => {
 
     return (
         <Center borderColor={borderBg} data-testid="header-standard" m="2rem auto">
-            <Flex w="100%" h="120px" alignItems="flex-end" maxW="1700" px={['5%', '10%']}>
+            <Flex w="100%" h="120px" alignItems="flex-end" maxW="1600px" px={['5%', '100px']}>
                 <HeaderLogo />
                 <NavBar isOpen={isOpen} onClose={onClose} btnRef={menuButtonRef} />
                 <IconButton

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,7 +11,7 @@ const Header = (): JSX.Element => {
 
     return (
         <Center borderColor={borderBg} data-testid="header-standard" m="2rem auto">
-            <Flex w="100%" h="120px" alignItems="flex-end" maxW="1600px" px={['5%', '100px']}>
+            <Flex w="90%" h="120px" alignItems="flex-end" maxW="1200px" px={['0', '5%', '50']}>
                 <HeaderLogo />
                 <NavBar isOpen={isOpen} onClose={onClose} btnRef={menuButtonRef} />
                 <IconButton

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -13,7 +13,13 @@ const Layout = ({ children }: Props): JSX.Element => {
         <Box overflow="hidden" pos="relative" minHeight="100vh" data-testid="layout">
             <AnimatedIcons n={50}>
                 <Header />
-                <Box maxW="2000" m="auto" px={['5%', '10%']} pb={['380px', '300px', '200px', '160px', '160px']}>
+                <Box
+                    maxW="2000"
+                    w="100%"
+                    m="auto"
+                    px={['5%', '100px']}
+                    pb={['380px', '300px', '200px', '160px', '160px']}
+                >
                     {children}
                 </Box>
                 <Footer />

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -14,10 +14,10 @@ const Layout = ({ children }: Props): JSX.Element => {
             <AnimatedIcons n={50}>
                 <Header />
                 <Box
-                    maxW="2000"
-                    w="100%"
+                    maxW="1500"
+                    w="90%"
                     m="auto"
-                    px={['5%', '100px']}
+                    px={['0', '5%', '50']}
                     pb={['380px', '300px', '200px', '160px', '160px']}
                 >
                     {children}


### PR DESCRIPTION
Siden paddingen på sidene ville øke med bredden på skjermen ville nettsiden se veldig rar ut på store skjermer (4k+). Sikkert ingen som var plaget av dette, men men.  Nettsiden skal se helt lik ut ellers.

Før:
<img src="https://user-images.githubusercontent.com/32321558/154805132-1282a860-4a52-4ae0-acc8-c1d73ca99fa2.png" style="height:300px;">

Etter:
<img src="https://user-images.githubusercontent.com/32321558/154805125-44f6de3f-3564-4bd1-8f24-390ab49103bc.png" style="height:300px;">

Før (hvis du har urealistisk stor skjerm):
<img src="https://user-images.githubusercontent.com/32321558/154805137-1fdb0331-a084-4b7e-af08-d5fdba49d0a3.png" style="height:300px;">

