### PR TITLE
:recycle: Refactored all api types and decoders into their own files

### DIFF
--- a/src/lib/api/decoders.ts
+++ b/src/lib/api/decoders.ts
@@ -136,9 +136,9 @@ const jobAdvertDecoder = record({
     title: string,
     logoUrl: string,
     deadline: string,
-    location: string,
+    locations: array(string),
     advertLink: string,
-    jobType: union(literal('fulltime'), literal('parttime'), literal('internship')),
+    jobType: union(literal('fulltime'), literal('parttime'), literal('internship'), literal('summerjob')),
     degreeYears: array(number),
     _createdAt: string,
 });

--- a/src/lib/api/happening.ts
+++ b/src/lib/api/happening.ts
@@ -1,38 +1,12 @@
 import axios from 'axios';
-import { array, decodeType, record, string, union, nil } from 'typescript-json-decoder';
-import { emptyArrayOnNilDecoder, spotRangeDecoder, questionDecoder } from './decoders';
+import { array } from 'typescript-json-decoder';
+import { happeningDecoder } from './decoders';
+import { Happening, HappeningType } from './types';
 import handleError from './errors';
 import { SanityAPI } from '.';
 
 // Automatically creates the Happening type with the
 // fields we specify in our happeningDecoder.
-type Happening = decodeType<typeof happeningDecoder>;
-const happeningDecoder = record({
-    _createdAt: string,
-    author: string,
-    title: string,
-    slug: string,
-    date: string,
-    body: string,
-    location: string,
-    locationLink: union(string, nil),
-    companyLink: union(string, nil),
-    registrationDate: union(string, nil),
-    logoUrl: union(string, nil),
-    contactEmail: union(string, nil),
-    additionalQuestions: (value) => emptyArrayOnNilDecoder(questionDecoder, value),
-    spotRanges: (value) => emptyArrayOnNilDecoder(spotRangeDecoder, value),
-    happeningType: (value) => {
-        if (value === 'BEDPRES' || value === 'bedpres') return HappeningType.BEDPRES;
-        else if (value === 'EVENT' || value === 'event') return HappeningType.EVENT;
-        else throw new Error(`Could not decode value '${JSON.stringify(value)}' to a HappeningType`);
-    },
-});
-
-enum HappeningType {
-    BEDPRES = 'BEDPRES',
-    EVENT = 'EVENT',
-}
 
 const HappeningAPI = {
     /**
@@ -160,5 +134,5 @@ const HappeningAPI = {
     },
 };
 
-export { HappeningType, HappeningAPI };
-export type { Happening };
+/* eslint-disable import/prefer-default-export */
+export { HappeningAPI };

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,16 +1,23 @@
 export { default as SanityAPI } from './api';
-export { HappeningAPI, HappeningType, type Happening } from './happening';
-export { type JobAdvert, JobAdvertAPI } from './job-advert';
-export { MinuteAPI, type Minute } from './minute';
-export { PostAPI, type Post } from './post';
+export { HappeningAPI } from './happening';
+export { JobAdvertAPI } from './job-advert';
+export { MinuteAPI } from './minute';
+export { PostAPI } from './post';
 export {
+    type Post,
+    type Minute,
+    type JobAdvert,
+    type Happening,
     type Answer,
-    Degree,
-    type FormValues,
     type Registration,
-    RegistrationAPI,
     type SpotRangeCount,
-    registrationRoute,
-} from './registration';
-export { StudentGroupAPI, type Member, type Profile, type StudentGroup } from './student-group';
-export { type SpotRange, type Question } from './decoders';
+    type Member,
+    type Profile,
+    type StudentGroup,
+    type SpotRange,
+    type Question,
+    HappeningType,
+    Degree,
+} from './types';
+export { RegistrationAPI, registrationRoute, type FormValues } from './registration';
+export { StudentGroupAPI } from './student-group';

--- a/src/lib/api/job-advert.ts
+++ b/src/lib/api/job-advert.ts
@@ -1,23 +1,9 @@
 import axios from 'axios';
-import { array, decodeType, literal, number, record, string, union } from 'typescript-json-decoder';
+import { array } from 'typescript-json-decoder';
 import SanityAPI from './api';
 import handleError from './errors';
-import { slugDecoder, Slug } from './decoders';
-
-type JobAdvert = decodeType<typeof jobAdvertDecoder>;
-const jobAdvertDecoder = record({
-    slug: string,
-    body: string,
-    companyName: string,
-    title: string,
-    logoUrl: string,
-    deadline: string,
-    locations: array(string),
-    advertLink: string,
-    jobType: union(literal('fulltime'), literal('parttime'), literal('internship'), literal('summerjob')),
-    degreeYears: array(number),
-    _createdAt: string,
-});
+import { slugDecoder, jobAdvertDecoder } from './decoders';
+import { Slug, JobAdvert } from './types';
 
 const JobAdvertAPI = {
     getPaths: async (): Promise<Array<string>> => {
@@ -94,5 +80,5 @@ const JobAdvertAPI = {
     },
 };
 
+/* eslint-disable import/prefer-default-export */
 export { JobAdvertAPI };
-export type { JobAdvert };

--- a/src/lib/api/minute.ts
+++ b/src/lib/api/minute.ts
@@ -1,17 +1,12 @@
 import axios from 'axios';
-import { array, boolean, decodeType, record, string } from 'typescript-json-decoder';
+import { array } from 'typescript-json-decoder';
 import handleError from './errors';
+import { minuteDecoder } from './decoders';
+import { Minute } from './types';
 import { SanityAPI } from '.';
 
 // Automatically creates the Minute type with the
 // fields we specify in our minuteDecoder.
-type Minute = decodeType<typeof minuteDecoder>;
-const minuteDecoder = record({
-    date: string,
-    allmote: boolean,
-    title: string,
-    document: (value) => record({ asset: record({ url: string }) })(value).asset.url,
-});
 
 const MinuteAPI = {
     /**
@@ -48,5 +43,5 @@ const MinuteAPI = {
     },
 };
 
+/* eslint-disable import/prefer-default-export */
 export { MinuteAPI };
-export type { Minute };

--- a/src/lib/api/post.ts
+++ b/src/lib/api/post.ts
@@ -1,19 +1,12 @@
 import axios from 'axios';
-import { array, decodeType, record, string } from 'typescript-json-decoder';
-import { slugDecoder } from './decoders';
+import { array } from 'typescript-json-decoder';
+import { slugDecoder, postDecoder } from './decoders';
+import { Post } from './types';
 import handleError from './errors';
 import { SanityAPI } from '.';
 
 // Automatically creates the Post type with the
 // fields we specify in our postDecoder.
-type Post = decodeType<typeof postDecoder>;
-const postDecoder = record({
-    title: string,
-    body: string,
-    slug: string,
-    author: (value) => record({ name: string })(value).name,
-    _createdAt: string,
-});
 
 const PostAPI = {
     /**
@@ -109,5 +102,5 @@ const PostAPI = {
     },
 };
 
+/* eslint-disable import/prefer-default-export */
 export { PostAPI };
-export type { Post };

--- a/src/lib/api/registration.ts
+++ b/src/lib/api/registration.ts
@@ -1,90 +1,9 @@
 import axios from 'axios';
-import { array, boolean, decodeType, number, optional, Pojo, record, string } from 'typescript-json-decoder';
+import { array } from 'typescript-json-decoder';
 import handleError from './errors';
+import { responseDecoder, registrationDecoder, spotRangeCountDecoder } from './decoders';
+import { Degree, Answer, Response, Registration, SpotRangeCount } from './types';
 import { HappeningType } from '.';
-
-enum Degree {
-    DTEK = 'DTEK',
-    DSIK = 'DSIK',
-    DVIT = 'DVIT',
-    BINF = 'BINF',
-    IMO = 'IMO',
-    IKT = 'IKT',
-    KOGNI = 'KOGNI',
-    INF = 'INF',
-    PROG = 'PROG',
-    ARMNINF = 'ARMNINF',
-    POST = 'POST',
-    MISC = 'MISC',
-}
-
-const degreeDecoder = (value: Pojo): Degree => {
-    const str: string = string(value);
-
-    switch (str) {
-        case 'DTEK':
-            return Degree.DTEK;
-        case 'DSIK':
-            return Degree.DSIK;
-        case 'DVIT':
-            return Degree.DVIT;
-        case 'BINF':
-            return Degree.BINF;
-        case 'IMO':
-            return Degree.IMO;
-        case 'IKT':
-            return Degree.IKT;
-        case 'KOGNI':
-            return Degree.KOGNI;
-        case 'INF':
-            return Degree.INF;
-        case 'PROG':
-            return Degree.PROG;
-        case 'ARMINF':
-            return Degree.ARMNINF;
-        case 'POST':
-            return Degree.POST;
-        default:
-            return Degree.MISC;
-    }
-};
-
-type Answer = decodeType<typeof answerDecoder>;
-const answerDecoder = record({
-    question: string,
-    answer: string,
-});
-
-type Registration = decodeType<typeof registrationDecoder>;
-const registrationDecoder = record({
-    email: string,
-    firstName: string,
-    lastName: string,
-    degree: degreeDecoder,
-    degreeYear: number,
-    slug: string,
-    terms: boolean,
-    submitDate: string,
-    waitList: boolean,
-    answers: array(answerDecoder),
-});
-
-type Response = decodeType<typeof responseDecoder>;
-const responseDecoder = record({
-    code: string,
-    title: string,
-    desc: string,
-    date: optional(string),
-});
-
-type SpotRangeCount = decodeType<typeof spotRangeCountDecoder>;
-const spotRangeCountDecoder = record({
-    spots: number,
-    minDegreeYear: number,
-    maxDegreeYear: number,
-    regCount: number,
-    waitListCount: number,
-});
 
 const genericError: { title: string; desc: string; date: string | undefined } = {
     title: 'Det har skjedd en feil.',
@@ -222,5 +141,5 @@ const RegistrationAPI = {
     },
 };
 
-export { Degree, RegistrationAPI, registrationRoute };
-export type { Answer, FormValues, Registration, Response, SpotRangeCount };
+export { RegistrationAPI, registrationRoute };
+export type { FormValues };

--- a/src/lib/api/student-group.ts
+++ b/src/lib/api/student-group.ts
@@ -1,28 +1,9 @@
 import axios from 'axios';
-import { array, decodeType, nil, record, string, union } from 'typescript-json-decoder';
+import { array } from 'typescript-json-decoder';
 import handleError from './errors';
-import { emptyArrayOnNilDecoder, slugDecoder } from './decoders';
+import { slugDecoder, studentGroupDecoder } from './decoders';
+import { StudentGroup } from './types';
 import { SanityAPI } from '.';
-
-type Profile = decodeType<typeof profileDecoder>;
-const profileDecoder = record({
-    name: string,
-    imageUrl: union(string, nil),
-});
-
-type Member = decodeType<typeof memberDecoder>;
-const memberDecoder = record({
-    role: string,
-    profile: profileDecoder,
-});
-
-type StudentGroup = decodeType<typeof studentGroupDecoder>;
-const studentGroupDecoder = record({
-    name: string,
-    slug: string,
-    info: string,
-    members: (value) => emptyArrayOnNilDecoder(memberDecoder, value),
-});
 
 const StudentGroupAPI = {
     getPaths: async (): Promise<Array<string>> => {
@@ -117,5 +98,5 @@ const StudentGroupAPI = {
     },
 };
 
+/* eslint-disable import/prefer-default-export */
 export { StudentGroupAPI };
-export type { Profile, Member, StudentGroup };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,84 @@
+import { decodeType } from 'typescript-json-decoder';
+import {
+    slugDecoder,
+    spotRangeDecoder,
+    questionDecoder,
+    profileDecoder,
+    memberDecoder,
+    studentGroupDecoder,
+    answerDecoder,
+    registrationDecoder,
+    responseDecoder,
+    spotRangeCountDecoder,
+    postDecoder,
+    minuteDecoder,
+    jobAdvertDecoder,
+    happeningDecoder,
+} from './decoders';
+
+type SpotRange = decodeType<typeof spotRangeDecoder>;
+
+type Question = decodeType<typeof questionDecoder>;
+
+type Slug = decodeType<typeof slugDecoder>;
+
+type Profile = decodeType<typeof profileDecoder>;
+
+type Member = decodeType<typeof memberDecoder>;
+
+type StudentGroup = decodeType<typeof studentGroupDecoder>;
+
+type Answer = decodeType<typeof answerDecoder>;
+
+type Registration = decodeType<typeof registrationDecoder>;
+
+type Response = decodeType<typeof responseDecoder>;
+
+type SpotRangeCount = decodeType<typeof spotRangeCountDecoder>;
+
+type Post = decodeType<typeof postDecoder>;
+
+type Minute = decodeType<typeof minuteDecoder>;
+
+type JobAdvert = decodeType<typeof jobAdvertDecoder>;
+
+type Happening = decodeType<typeof happeningDecoder>;
+
+enum HappeningType {
+    BEDPRES = 'BEDPRES',
+    EVENT = 'EVENT',
+}
+
+enum Degree {
+    DTEK = 'DTEK',
+    DSIK = 'DSIK',
+    DVIT = 'DVIT',
+    BINF = 'BINF',
+    IMO = 'IMO',
+    IKT = 'IKT',
+    KOGNI = 'KOGNI',
+    INF = 'INF',
+    PROG = 'PROG',
+    ARMNINF = 'ARMNINF',
+    POST = 'POST',
+    MISC = 'MISC',
+}
+
+export type {
+    Slug,
+    SpotRange,
+    Question,
+    Profile,
+    Member,
+    StudentGroup,
+    Answer,
+    Registration,
+    Response,
+    SpotRangeCount,
+    Post,
+    Minute,
+    JobAdvert,
+    Happening,
+};
+
+export { HappeningType, Degree };


### PR DESCRIPTION
Det ble litt uryddig når alle api modulene implementerte og exporterte sine egne typer og decoders. Samlet alle api type definisjoner i types.ts og alle type decoders i decoders.ts

Måtte legge til en liten eslint ignore før exporten på fem av filene, da "export { ... } from module" i api/index.ts ikke fungerer hvis man bruker default export. 