### PR TITLE
🚑 Sort registrations by waitlist

### DIFF
--- a/src/pages/registration/[slug].tsx
+++ b/src/pages/registration/[slug].tsx
@@ -126,17 +126,23 @@ const RegistrationsPage = ({ registrations, error, link, backendUrl }: Props): J
                             </Tr>
                         </Thead>
                         <Tbody>
-                            {registrations.map((reg) => {
-                                return (
-                                    <RegistrationRow
-                                        key={reg.email}
-                                        registration={reg}
-                                        questions={questions}
-                                        link={link}
-                                        backendUrl={backendUrl}
-                                    />
-                                );
-                            })}
+                            {registrations
+                                .sort((a, b) => {
+                                    if (a.waitList && !b.waitList) return 1;
+                                    else if (!a.waitList && b.waitList) return -1;
+                                    else return 0;
+                                })
+                                .map((reg) => {
+                                    return (
+                                        <RegistrationRow
+                                            key={reg.email}
+                                            registration={reg}
+                                            questions={questions}
+                                            link={link}
+                                            backendUrl={backendUrl}
+                                        />
+                                    );
+                                })}
                         </Tbody>
                     </Table>
                 </>


### PR DESCRIPTION
Det er umulig å se hvilken påmelding som blir tatt av ventelisten på arrangementer med flere spotranges. Nå blir de sortert etter venteliste uansett spotrange.