### PR TITLE
👽 Add case that date can be null in backend response 

### DIFF
--- a/src/lib/api/decoders.ts
+++ b/src/lib/api/decoders.ts
@@ -103,7 +103,7 @@ const responseDecoder = record({
     code: string,
     title: string,
     desc: string,
-    date: optional(string),
+    date: optional(union(string, nil)),
 });
 
 const spotRangeCountDecoder = record({

--- a/src/lib/api/registration.ts
+++ b/src/lib/api/registration.ts
@@ -4,10 +4,10 @@ import { responseDecoder, registrationDecoder } from './decoders';
 import { ErrorMessage, Degree, Answer, Response, Registration } from './types';
 import { HappeningType } from '.';
 
-const genericError: { title: string; desc: string; date: string | undefined } = {
+const genericError = {
     title: 'Det har skjedd en feil.',
     desc: 'Vennligst prøv igjen',
-    date: undefined,
+    date: null,
 };
 
 // Values directly from the form (aka form fields)


### PR DESCRIPTION
kotlinx.serialization bruker ikke undefined for valgfrie felter.
La til at date kan være null.

### Trengs av https://github.com/echo-webkom/echo-web-backend/pull/298