### PR TITLE
🔧 Set session maxAge to match Feide expire date

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,9 @@
 import NextAuth from 'next-auth';
 
 export default NextAuth({
+    session: {
+        maxAge: 3600,
+    },
     callbacks: {
         // eslint-disable-next-line @typescript-eslint/require-await
         async jwt({ token, account }) {


### PR DESCRIPTION
Så NextAuth skjønner at du må logge inn på nytt.

1 time er det samme som Feide har. Vet ikke helt hvor vi kan øke dette, men de burde i første omgang matche.

### Forhindrer det her:

![2022-04-25_23:47:53](https://user-images.githubusercontent.com/6720179/165311575-efac6f5c-b4fd-4be8-94bd-7a4e32a742f9.png)

## Som skjer pga. backend sier dette (og ikke gir oss en `User` fra databasen):

![2022-04-25_23:49:16](https://user-images.githubusercontent.com/6720179/165311691-09bdbfb1-8127-43e9-81a6-2e201c798924.png)


